### PR TITLE
fix: fix warning `Timer '[modern-screenshot] canvas to blob'

### DIFF
--- a/src/converts/dom-to-blob.ts
+++ b/src/converts/dom-to-blob.ts
@@ -22,6 +22,7 @@ export async function domToBlob(node: any, options?: any) {
     } else if (type === 'image/jpeg') {
       uint8Array = changeJpegDpi(uint8Array, dpi)
     }
+    log.timeEnd('canvas to blob')
     return new Blob([uint8Array, blob.slice(33)], { type })
   }
   log.timeEnd('canvas to blob')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I got following warning in console.

![image](https://github.com/qq15725/modern-screenshot/assets/2234012/89235a38-e21e-4db6-838a-5e157b103926)

This PR will fix that.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Pull Request Guidelines](https://github.com/qq15725/modern-screenshot/blob/master/.github/pull-request-guidelines.md) and follow the [PR Title Convention](https://github.com/qq15725/modern-screenshot/blob/master/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
