### PR TITLE
fix: when bgImage eq to none, still drawImageCount

### DIFF
--- a/src/embed-css-style-image.ts
+++ b/src/embed-css-style-image.ts
@@ -17,7 +17,7 @@ export function embedCssStyleImage(
   return properties
     .map(property => {
       const value = style.getPropertyValue(property)
-      if (!value) {
+      if (!value || value === 'none') {
         return null
       }
       if (IN_SAFARI || IN_FIREFOX) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

when embed style include `background-image` and **value** equal to `none`,  `context.drawImageCount` will be ++, that slow in safari.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

about style declaration:

```
background-image: none;
border-image-source: none;
-webkit-border-image: none;
-webkit-mask-image: none;
list-style-image: none;
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Pull Request Guidelines](https://github.com/qq15725/modern-screenshot/blob/master/.github/pull-request-guidelines.md) and follow the [PR Title Convention](https://github.com/qq15725/modern-screenshot/blob/master/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
