### PR TITLE
feat: add `includeStyleProperties` option

### DIFF
--- a/src/copy-css-styles.ts
+++ b/src/copy-css-styles.ts
@@ -13,7 +13,7 @@ export function copyCssStyles<T extends HTMLElement | SVGElement>(
   const clonedStyle = cloned.style
   const computedStyle = ownerWindow!.getComputedStyle(node)
   const defaultStyle = getDefaultStyle(node, null, context)
-  const diffStyle = getDiffStyle(computedStyle, defaultStyle)
+  const diffStyle = getDiffStyle(computedStyle, defaultStyle, context.includeStyleProperties)
 
   // fix
   diffStyle.delete('transition-property')

--- a/src/copy-pseudo-class.ts
+++ b/src/copy-pseudo-class.ts
@@ -47,7 +47,7 @@ export function copyPseudoClass<T extends HTMLElement | SVGElement>(
       `content: '${ content }';`,
     ]
 
-    const diffStyle = getDiffStyle(computedStyle, defaultStyle)
+    const diffStyle = getDiffStyle(computedStyle, defaultStyle, context.includeStyleProperties)
 
     // fix
     diffStyle.delete('content')

--- a/src/create-context.ts
+++ b/src/create-context.ts
@@ -56,6 +56,7 @@ export async function createContext<T extends Node>(node: T, options?: Options &
     onCloneNode: null,
     onEmbedNode: null,
     onCreateForeignObjectSvg: null,
+    includeStyleProperties: null,
     autoDestruct: false,
     ...options,
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -183,4 +183,12 @@ export interface Options {
    * Triggered after a ForeignObjectSvg is created
    */
   onCreateForeignObjectSvg?: ((svg: SVGSVGElement) => void) | null
+
+  /**
+   * An array of style property names.
+   * Can be used to manually specify which style properties are
+   * included when cloning nodes.
+   * This can be useful for performance-critical scenarios.
+   */
+  includeStyleProperties?: string[] | null
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Please see for details:

- https://github.com/qq15725/modern-screenshot/issues/62
- https://github.com/bubkoo/html-to-image/pull/436/files

In this PR:

* users can now manually specify which style properties are included

This commit is applied from https://github.com/bubkoo/html-to-image/pull/436

### Additional context

No

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Pull Request Guidelines](https://github.com/qq15725/modern-screenshot/blob/master/.github/pull-request-guidelines.md) and follow the [PR Title Convention](https://github.com/qq15725/modern-screenshot/blob/master/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
