### PR TITLE
Fix textarea content rendered twice

### DIFF
--- a/src/copy-input-value.ts
+++ b/src/copy-input-value.ts
@@ -4,10 +4,6 @@ export function copyInputValue<T extends HTMLElement | SVGElement>(
   node: T,
   cloned: T,
 ): void {
-  if (isTextareaElement(node)) {
-    cloned.innerHTML = node.value
-  }
-
   if (isTextareaElement(node) || isInputElement(node) || isSelectElement(node)) {
     cloned.setAttribute('value', node.value)
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR fixes #50, i.e. content in textareas being rendered twice. This appears to be caused by `copyInputValue` copying the original textarea's `value` into the clone textarea's `innerHTML`, after which the `cloneChildNodes` call in [`src/clone-node.ts:223`](https://github.com/qq15725/modern-screenshot/blob/main/src/clone-node.ts#L223) appends clones of the textarea's child nodes to the same `innerHTML`. This effectively repeats what `copyInputValue` already did, resulting in the original content appearing twice in the clone. I fixed the issue by removing the copying that happens in `copyInputValue`.

Before:
![](https://github.com/user-attachments/assets/a550d2bb-a823-48da-93d3-95c84755d458)

After:
![](https://github.com/user-attachments/assets/7be6493b-24d0-47d1-9151-40c707e5ba98)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
The font rendering on my system is slightly different from the one used to generate the test fixture images, so I did not add a unit test because it'll likely fail on the system that was used to generate the existing fixtures.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Pull Request Guidelines](https://github.com/qq15725/modern-screenshot/blob/main/.github/pull-request-guidelines.md) and follow the [PR Title Convention](https://github.com/qq15725/modern-screenshot/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
