### PR TITLE
feat: Add the onCloneEachNode callback to execute when each node is cloned.

### DIFF
--- a/src/clone-node.ts
+++ b/src/clone-node.ts
@@ -141,7 +141,7 @@ export async function cloneNode<T extends Node>(
   isRoot = false,
   addWordToFontFamilies?: (text: string) => void,
 ): Promise<Node> {
-  const { ownerDocument, ownerWindow, fontFamilies } = context
+  const { ownerDocument, ownerWindow, fontFamilies, onCloneEachNode } = context
 
   if (ownerDocument && isTextNode(node)) {
     if (addWordToFontFamilies && /\S/.test(node.data)) {
@@ -228,12 +228,16 @@ export async function cloneNode<T extends Node>(
       )
     }
 
+    await onCloneEachNode?.(cloned)
+
     return cloned
   }
 
   const cloned = node.cloneNode(false)
 
   await cloneChildNodes(node, cloned, context)
+
+  await onCloneEachNode?.(cloned)
 
   return cloned
 }

--- a/src/create-context.ts
+++ b/src/create-context.ts
@@ -53,6 +53,7 @@ export async function createContext<T extends Node>(node: T, options?: Options &
     drawImageInterval: 100,
     workerUrl: null,
     workerNumber,
+    onCloneEachNode: null,
     onCloneNode: null,
     onEmbedNode: null,
     onCreateForeignObjectSvg: null,

--- a/src/options.ts
+++ b/src/options.ts
@@ -199,6 +199,11 @@ export interface Options {
   workerNumber?: number
 
   /**
+   * Triggered after each node is cloned
+   */
+  onCloneEachNode?: ((cloned: Node) => void | Promise<void>) | null
+
+  /**
    * Triggered after a node is cloned
    */
   onCloneNode?: ((cloned: Node) => void | Promise<void>) | null


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently, certain nodes in some scenarios are encountering rendering issues(e.g.[#104 ](https://github.com/qq15725/modern-screenshot/issues/104)). To address this, I need to handle these specific nodes. My current approach involves searching for specific class names within the `onCloneNode` method and performing operations accordingly. However, as the number of cases increases, each scenario requires a separate queryAll call, which becomes time-consuming and cumbersome. A more efficient solution would be to implement a method that iterates through each node to streamline the process.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Pull Request Guidelines](https://github.com/qq15725/modern-screenshot/blob/main/.github/pull-request-guidelines.md) and follow the [PR Title Convention](https://github.com/qq15725/modern-screenshot/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
